### PR TITLE
Expose WebSocket connection events

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ client.on('ChannelDtmfReceived', event => {
     console.log('DTMF received:', event.digit);
 });
 
+// Subscribe to WebSocket connection events
+client.on('connected', () => {
+    console.log('WebSocket connected');
+});
+
+client.on('reconnected', info => {
+    console.log('WebSocket reconnected:', info);
+});
+
+client.on('disconnected', () => {
+    console.log('WebSocket disconnected');
+});
+
+client.on('reconnectFailed', err => {
+    console.error('WebSocket reconnect failed:', err);
+});
+
+client.on('error', err => {
+    console.error('WebSocket error:', err);
+});
+
 // Close WebSocket connection
 client.closeWebSocket();
 ```

--- a/src/ari-client/ariClient.ts
+++ b/src/ari-client/ariClient.ts
@@ -7,8 +7,9 @@ import type {
   Logger,
 } from './interfaces';
 import type {
-  TypedWebSocketEventListener,
-  WebSocketEventListener,
+  WebSocketClientEventType,
+  WebSocketClientEventListener,
+  WebSocketClientEvents,
 } from './interfaces/websocket.types';
 import { Applications } from './resources/applications.js';
 import { Asterisk } from './resources/asterisk';
@@ -38,7 +39,10 @@ export class AriClient {
   private readonly baseClient: BaseClient;
   public readonly logger: Logger;
   private webSocketClient?: WebSocketClient;
-  private eventListeners = new Map<string, WebSocketEventListener[]>();
+  private eventListeners = new Map<
+    WebSocketClientEventType,
+    WebSocketClientEventListener<WebSocketClientEventType>[]
+  >();
 
   public readonly channels: Channels;
   public readonly endpoints: Endpoints;
@@ -73,7 +77,7 @@ export class AriClient {
       config.username,
       config.password,
       undefined,
-      this.logger,
+      this.logger
     );
 
     // Initialize resource handlers
@@ -129,7 +133,10 @@ export class AriClient {
       // Limpar listeners do cliente ARI
       this.eventListeners.forEach((listeners, event) => {
         listeners.forEach((listener) => {
-          this.off(event as WebSocketEvent['type'], listener);
+          this.off(
+            event as WebSocketClientEventType,
+            listener as WebSocketClientEventListener<WebSocketClientEventType>
+          );
         });
       });
       this.eventListeners.clear();
@@ -173,7 +180,7 @@ export class AriClient {
         apps,
         subscribedEvents,
         this,
-        this.logger,
+        this.logger
       );
 
       await this.webSocketClient.connect();
@@ -252,9 +259,9 @@ export class AriClient {
    * @param {Function} listener - Callback function for handling the event
    * @throws {Error} If WebSocket is not connected
    */
-  public on<T extends WebSocketEvent['type']>(
+  public on<T extends WebSocketClientEventType>(
     event: T,
-    listener: TypedWebSocketEventListener<T>
+    listener: WebSocketClientEventListener<T>
   ): void {
     if (!this.webSocketClient) {
       throw new Error('WebSocket is not connected');
@@ -262,8 +269,14 @@ export class AriClient {
 
     // 🔹 Verifica se o listener já está registrado para evitar duplicação
     const existingListeners = this.eventListeners.get(event) || [];
-    if (existingListeners.includes(listener as WebSocketEventListener)) {
-      this.logger.warn(`Listener already registered for event ${event}, reusing.`);
+    if (
+      existingListeners.includes(
+        listener as WebSocketClientEventListener<WebSocketClientEventType>
+      )
+    ) {
+      this.logger.warn(
+        `Listener already registered for event ${event}, reusing.`
+      );
       return;
     }
 
@@ -271,7 +284,9 @@ export class AriClient {
     this.webSocketClient.on(event, listener);
 
     // Armazenar o listener para referência e limpeza futura
-    existingListeners.push(listener as WebSocketEventListener);
+    existingListeners.push(
+      listener as WebSocketClientEventListener<WebSocketClientEventType>
+    );
     this.eventListeners.set(event, existingListeners);
 
     this.logger.log(`Event listener successfully registered for ${event}`);
@@ -284,9 +299,9 @@ export class AriClient {
    * @param {Function} listener - Callback function for handling the event
    * @throws {Error} If WebSocket is not connected
    */
-  public once<T extends WebSocketEvent['type']>(
+  public once<T extends WebSocketClientEventType>(
     event: T,
-    listener: TypedWebSocketEventListener<T>
+    listener: WebSocketClientEventListener<T>
   ): void {
     if (!this.webSocketClient) {
       throw new Error('WebSocket is not connected');
@@ -294,22 +309,26 @@ export class AriClient {
 
     // 🔹 Check if an identical listener already exists to avoid duplication
     const existingListeners = this.eventListeners.get(event) || [];
-    if (existingListeners.includes(listener as WebSocketEventListener)) {
+    if (
+      existingListeners.includes(
+        listener as WebSocketClientEventListener<WebSocketClientEventType>
+      )
+    ) {
       this.logger.warn(
         `One-time listener already registered for event ${event}, reusing.`
       );
       return;
     }
 
-    const wrappedListener = (data: Extract<WebSocketEvent, { type: T }>) => {
+    const wrappedListener = (data: WebSocketClientEvents[T]) => {
       listener(data);
-      this.off(event, wrappedListener);
+      this.off(event, wrappedListener as WebSocketClientEventListener<T>);
     };
 
     this.webSocketClient.once(event, wrappedListener);
     this.eventListeners.set(event, [
       ...existingListeners,
-      wrappedListener as WebSocketEventListener,
+      wrappedListener as WebSocketClientEventListener<WebSocketClientEventType>,
     ]);
 
     this.logger.log(`One-time event listener registered for ${event}`);
@@ -321,9 +340,9 @@ export class AriClient {
    * @param {T} event - The event type to remove listener for
    * @param {Function} listener - The listener function to remove
    */
-  public off<T extends WebSocketEvent['type']>(
+  public off<T extends WebSocketClientEventType>(
     event: T,
-    listener: TypedWebSocketEventListener<T>
+    listener: WebSocketClientEventListener<T>
   ): void {
     if (!this.webSocketClient) {
       this.logger.warn('No WebSocket connection to remove listener from');
@@ -335,7 +354,9 @@ export class AriClient {
     this.eventListeners.set(
       event,
       existingListeners.filter(
-        (l) => l !== (listener as WebSocketEventListener)
+        (l) =>
+          l !==
+          (listener as WebSocketClientEventListener<WebSocketClientEventType>)
       )
     );
 
@@ -353,7 +374,9 @@ export class AriClient {
         return;
       }
 
-      this.logger.log('Closing WebSocket connection and cleaning up listeners.');
+      this.logger.log(
+        'Closing WebSocket connection and cleaning up listeners.'
+      );
 
       const closeTimeout = setTimeout(() => {
         if (this.webSocketClient) {
@@ -366,14 +389,14 @@ export class AriClient {
       this.eventListeners.forEach((listeners, event) => {
         listeners.forEach((listener) => {
           this.webSocketClient?.off(
-            event as WebSocketEvent['type'],
-            listener as (...args: any[]) => void
+            event as WebSocketClientEventType,
+            listener as WebSocketClientEventListener<WebSocketClientEventType>
           );
         });
       });
       this.eventListeners.clear();
 
-      this.webSocketClient.once('close', () => {
+      this.webSocketClient.once('disconnected', () => {
         clearTimeout(closeTimeout);
         this.webSocketClient = undefined;
         this.logger.log('WebSocket connection closed');

--- a/src/ari-client/interfaces/index.ts
+++ b/src/ari-client/interfaces/index.ts
@@ -67,6 +67,12 @@ export type {
   PeerStatusChange,
 } from './events.types.js';
 export type {
+  WebSocketReconnectInfo,
+  WebSocketClientEvents,
+  WebSocketClientEventType,
+  WebSocketClientEventListener,
+} from './websocket.types.js';
+export type {
   AddChannelRequest,
   RemoveChannelRequest,
   CreateBridgeRequest,

--- a/src/ari-client/interfaces/websocket.types.ts
+++ b/src/ari-client/interfaces/websocket.types.ts
@@ -1,10 +1,28 @@
-import type { WebSocketEvent } from './events.types';
+import type { WebSocketEvent, WebSocketEventType } from './events.types';
 
 export type WebSocketEventListener = (data: WebSocketEvent) => void;
 
-/**
- * Tipo específico para um listener de um tipo de evento específico
- */
 export type TypedWebSocketEventListener<T extends WebSocketEvent['type']> = (
   data: Extract<WebSocketEvent, { type: T }>
+) => void;
+
+export interface WebSocketReconnectInfo {
+  apps: string[];
+  subscribedEvents?: WebSocketEventType[];
+}
+
+export type WebSocketClientEvents = {
+  connected: void;
+  disconnected: void;
+  reconnected: WebSocketReconnectInfo;
+  reconnectFailed: Error;
+  error: Error;
+} & {
+  [K in WebSocketEventType]: Extract<WebSocketEvent, { type: K }>;
+};
+
+export type WebSocketClientEventType = keyof WebSocketClientEvents;
+
+export type WebSocketClientEventListener<T extends WebSocketClientEventType> = (
+  data: WebSocketClientEvents[T]
 ) => void;

--- a/src/ari-client/websocketClient.ts
+++ b/src/ari-client/websocketClient.ts
@@ -3,7 +3,14 @@ import { type IBackOffOptions, backOff } from 'exponential-backoff';
 import WebSocket from 'ws';
 import type { AriClient } from './ariClient';
 import type { BaseClient } from './baseClient.js';
-import type { WebSocketEvent, WebSocketEventType, Logger } from './interfaces';
+import type {
+  WebSocketEvent,
+  WebSocketEventType,
+  Logger,
+  WebSocketClientEvents,
+  WebSocketClientEventType,
+  WebSocketClientEventListener,
+} from './interfaces';
 
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 30;
 const DEFAULT_STARTING_DELAY = 500;
@@ -518,5 +525,26 @@ export class WebSocketClient extends EventEmitter {
 
     // Remover todos os listeners
     this.removeAllListeners();
+  }
+
+  public override on<E extends WebSocketClientEventType>(
+    event: E,
+    listener: WebSocketClientEventListener<E>
+  ): this {
+    return super.on(event, listener);
+  }
+
+  public override once<E extends WebSocketClientEventType>(
+    event: E,
+    listener: WebSocketClientEventListener<E>
+  ): this {
+    return super.once(event, listener);
+  }
+
+  public override off<E extends WebSocketClientEventType>(
+    event: E,
+    listener: WebSocketClientEventListener<E>
+  ): this {
+    return super.off(event, listener);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,10 @@ export type {
 export type {
   WebSocketEvent,
   WebSocketEventType,
+  WebSocketClientEvents,
+  WebSocketClientEventType,
+  WebSocketClientEventListener,
+  WebSocketReconnectInfo,
   // Eventos individuais
   ChannelDtmfReceived,
   ChannelDialplanEvent,


### PR DESCRIPTION
## Summary
- merge WebSocket connection events into generic event map
- type WebSocketClient's event emitter methods
- allow AriClient to listen for connection events without casts
- document connection event usage in README

## Testing
- `npm run build`
- `git fetch upstream master` *(fails: requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68690d2bd3dc832998a73315399d7370